### PR TITLE
fix: transform found Rally artifacts to upper case

### DIFF
--- a/.github/workflows/stack-linter.yml
+++ b/.github/workflows/stack-linter.yml
@@ -45,7 +45,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3.15.5
+        uses: github/super-linter@v3.16.1
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFiles: ['<rootDir>/test/setup.js'],
+};

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -789,6 +789,17 @@ class RallyValidate {
    * @returns {Promise<void>}
    */
   async rerunCheck (context) {
+    await this.rerunCheckWithRally (context, this.initializeRallyClient)
+  }
+
+  /**
+   * Process the pull request with the given initializeRallyClient
+   *
+   * @param context
+   * @param _initializeRallyClient
+   * @returns {Promise<void>}
+   */
+  async rerunCheckWithRally(context, _initializeRallyClient) {
     const prContext = context
 
     const defaultConfig = await this.getDefaultConfig(context)
@@ -819,7 +830,7 @@ class RallyValidate {
     })
     prContext.payload.pull_request = prResponse.data
 
-    this.handlePullRequest(prContext)
+    await this.handlePullRequestWithRally(prContext, _initializeRallyClient)
   }
 
   /**

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -726,7 +726,9 @@ class RallyValidate {
       const regexp = RegExp('\\b' + prefix + '[0-9]{1,10}\\b', 'gi')
       const artifactMatches = text.match(regexp)
       if (artifactMatches) {
-        artifacts = artifacts.concat(artifactMatches)
+        artifacts = artifacts.concat(artifactMatches.map(
+          artifactMatch => artifactMatch.toUpperCase())
+        )
       }
     })
     return artifacts
@@ -769,7 +771,7 @@ class RallyValidate {
             const artifactMatches = matches.map(match => {
               const artifactMatch = {
                 command: command,
-                artifact: match.substr(command.length + 2)
+                artifact: match.substr(command.length + 2).toUpperCase()
               }
               return artifactMatch
             })

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -132,6 +132,17 @@ class RallyValidate {
    * @returns {Promise<void>}
    */
   async handlePullRequest (context) {
+    await this.handlePullRequestWithRally (context, this.initializeRallyClient)
+  }
+
+  /**
+   * Process the pull request with the given initializeRallyClient
+   *
+   * @param context
+   * @param _initializeRallyClient
+   * @returns {Promise<void>}
+   */
+  async handlePullRequestWithRally(context, _initializeRallyClient) {
     // Initialize Rally Artifacts
     const rallyArtifacts = {}
 
@@ -155,7 +166,7 @@ class RallyValidate {
     await this.setStatusPending(context, config)
 
     try {
-      const rallyClient = await this.initializeRallyClient(config)
+      const rallyClient = await _initializeRallyClient(config)
       // Get commit comments for validation
       rallyArtifacts.commits = await this.checkCommitMessages(context, config, rallyClient)
       // Get the PR title for validation
@@ -408,8 +419,12 @@ class RallyValidate {
    * @returns {Promise<void>}
    */
   async commentOnPull (context, message) {
-    const params = context.artifact({ body: message })
-    await context.github.artifacts.createComment(params)
+    await context.github.issues.createComment({
+      owner: context.payload.repository.owner.login,
+      repo: context.payload.repository.name,
+      issue_number: context.payload.pull_request.number,
+      body: message
+    })
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5295,9 +5295,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "outdent": "^0.8.0",
     "probot": "^9.14.1",
     "rally": "^2.1.3",
-    "js-yaml": "^4.0.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "jest": "^26.6.3",

--- a/rally.yml
+++ b/rally.yml
@@ -15,7 +15,7 @@ checkCommitMessages: true
 mergeOnPRBody: true
 
 # Comment on the PR in addition to the check message? (true | false)
-commentOnPull: false
+commentOnPull: true
 
 rally:
   server: https://rally1.rallydev.com

--- a/rally.yml
+++ b/rally.yml
@@ -15,7 +15,7 @@ checkCommitMessages: true
 mergeOnPRBody: true
 
 # Comment on the PR in addition to the check message? (true | false)
-commentOnPull: true
+commentOnPull: false
 
 rally:
   server: https://rally1.rallydev.com

--- a/test/RallyValidate.test.js
+++ b/test/RallyValidate.test.js
@@ -66,9 +66,9 @@ describe('JiraIssueValidate', () => {
           {
             _ref: 'https://rallydomain.com/my-ref',
             Project: {
-              _refObjectName: "Sample Project"
+              _refObjectName: 'Sample Project'
             },
-            ScheduleState: "Defined"
+            ScheduleState: 'Defined'
           }
         ]
       })),
@@ -83,11 +83,11 @@ describe('JiraIssueValidate', () => {
       expect(context.config).toHaveBeenCalled()
       expect(context.github.checks.create.mock.calls).toEqual([
         [context.repo(expect.objectContaining({
-          "status": "in_progress",
+          status: 'in_progress'
         }))],
         [context.repo(expect.objectContaining({
-          "conclusion": "success",
-          "status": "completed",
+          conclusion: 'success',
+          status: 'completed'
         }))]
       ])
     })

--- a/test/RallyValidate.test.js
+++ b/test/RallyValidate.test.js
@@ -74,12 +74,12 @@ describe('JiraIssueValidate', () => {
       })),
       update: jest.fn()
     }
-    initializeRallyClient = jest.fn().mockImplementation(() => Promise.resolve(rallyClient))
+    initializeRallyClient = jest.fn().mockImplementation(() => Promise.resolve(rallyClient)) // eslint-disable-line
   })
 
   describe('hook', () => {
     it('pull_request.synchronize', async () => {
-      await handler.handlePullRequestWithRally(context, initializeRallyClient)
+      await handler.handlePullRequestWithRally(context, initializeRallyClient) // eslint-disable-line
       expect(context.config).toHaveBeenCalled()
       expect(context.github.checks.create.mock.calls).toEqual([
         [context.repo(expect.objectContaining({

--- a/test/fixtures/check_run_rerequested.json
+++ b/test/fixtures/check_run_rerequested.json
@@ -1,0 +1,17 @@
+{
+  "check_run": {
+    "name": "integrations/rally",
+    "check_suite": {
+      "pull_requests": [
+        {
+          "number": 100
+        }
+      ]
+    }
+  },
+  "repository": {
+    "owner": {
+      "login": "acme"
+    }
+  }
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', (err) => {
+  fail(err);
+});


### PR DESCRIPTION
since Rally API returns 'unefined' errors for lowercase artifacts.
"Error occurred while validating Rally Artifacts: Error: Not able to parse artifact type: undefined"

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one -->
Fixes #199

<!-- Describe what the changes are -->
## Proposed Changes

- allow lowercase artifacts like us12345 in text, but transform it to uppercase for the Rally API

## Readiness Checklist

- [ ] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [ ] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
