### PR TITLE
fix: #199 transform found Rally artifacts to upper case

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -726,7 +726,9 @@ class RallyValidate {
       const regexp = RegExp('\\b' + prefix + '[0-9]{1,10}\\b', 'gi')
       const artifactMatches = text.match(regexp)
       if (artifactMatches) {
-        artifacts = artifacts.concat(artifactMatches)
+        artifacts = artifacts.concat(artifactMatches.map(
+          artifactMatch => artifactMatch.toUpperCase())
+        )
       }
     })
     return artifacts
@@ -769,7 +771,7 @@ class RallyValidate {
             const artifactMatches = matches.map(match => {
               const artifactMatch = {
                 command: command,
-                artifact: match.substr(command.length + 2)
+                artifact: match.substr(command.length + 2).toUpperCase()
               }
               return artifactMatch
             })


### PR DESCRIPTION
since Rally API returns 'undefined' errors for lowercase artifacts.
"Error occurred while validating Rally Artifacts: Error: Not able to parse artifact type: undefined"

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one -->
Fixes #199

<!-- Describe what the changes are -->
## Proposed Changes

- allow lowercase artifacts like us12345 in text, but transform it to uppercase for the Rally API

## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
